### PR TITLE
Fix install; update `jot` db/config dir to `~/.jot`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include jot/*sql
+include jot/default_config.csv

--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ command line task management interface and database
 ## Overview
 
 - JOT is a capable task and note manager built as a command-line tool.
-- Data is stored in a sqlite3 database which is created the first time jot.py is run
-- An interface to the database is written in Python
-- A long-form note editing mode is available, and the editor is configurable, default depends on os: vim or notepad
-- For easy access (Linux): add similar to `alias jot='python3 /PATH/TO/jot/jot/jot.py'` to your `.bashrc`
-- Usage can be accessed after installing by typing `jot --help` or `jot -h`
-- Typing `jot` (or `python3 jot.py` without the soft link) gives a summary of active items
+- Data is stored in a a sqlite3 database which is created the first time jot is run
+- An interface to the database is built in Python
+- Long-form editing is available with a text editor. Default is vim on Linux/MacOS and notepad on Windows.
+- For easy access, see installation instructions below. Alternatively (Linux/MacOS), add `alias jot='python3 /home/dallan/jot/jot.py'` to your `.bashrc`
+- Usage can be accessed by typing `jot --help` or `jot -h`
+- Running `jot` without any arguments gives a summary of active items
 - Items can be nested by assigning a parent
 - Ability to add attachments is envisioned in the database but not yet implemented
+
+## Installation
+After cloning the repository, run the following command: `python setup.py install`. `jot` should now be usable without adding an alias.
 
 ## Windows
 

--- a/jot/jot.py
+++ b/jot/jot.py
@@ -52,11 +52,11 @@ class Jot:
             self.config['db_dir'] = self.JOT_DIR
             self.write_config(self.config)
             # TODO DELETE IN LATER VERSION--TO MIGRATE existing.sqlites to dat location
-            sourcefiles = os.listdir(self.JOT_DIR)
-            destinationpath = self.JOT_DIR / 'dat'
+            sourcefiles = os.listdir(self.SRC_DIR)
+            destinationpath = self.JOT_DIR
             for file in sourcefiles:
                 if file.endswith('.sqlite'):
-                    shutil.move(self.JOT_DIR / file, self.JOT_DIR / 'dat' / file)
+                    shutil.move(self.SRC_DIR / file, self.JOT_DIR / file)
 
         self.snippet_width = int(d['snippet_width']) # notes column print width
         self.DB_NAME = d['db_name']

--- a/jot/jot.py
+++ b/jot/jot.py
@@ -26,14 +26,14 @@ class Jot:
         self.connect()
         self.parse_inputs()
         self.main()
-    
+
     def read_config(self):
         ## RSD TODO: Think about where sqlite database goes when installed
         self.JOT_DIR = Path(__file__).parent.parent
-        
+
         def_conf = self.JOT_DIR / 'jot' / 'default_config.csv'
         conf = self.JOT_DIR / 'dat' / 'config.csv'
-        
+
         if conf.exists():
             p = conf
         else:
@@ -61,7 +61,7 @@ class Jot:
         self.DB_NAME = d['db_name']
         self.DB_DIR = Path(d['db_dir'])
         self.DB = self.DB_DIR / self.DB_NAME
-        
+
         # see ansi 256 color codes: https://www.ditig.com/256-colors-cheat-sheet
         self.palette = [d['color_line'], d['color_note'], d['color_todo'],
                 d['color_done'], d['color_drop'], d['color_part'], d['color_id'],
@@ -372,24 +372,24 @@ class Jot:
     #             '\n' + row[3] + \
     #             '\n\n' + ('created ' + row[4] + ' & modified ' + row[5]).ljust(self.snippet_width + 17, ">").rjust(self.snippet_width + 24, "<") \
     #             , cmd=self.view_note_cmd)
-    # 
+    #
     #     gen_parts = self.gen_symbol(gen)
     #     sts_str = (row[9] if row[9] else '').center(3, '|')
     #     gen_str = gen_parts[0]
-    #     
+    #
     #     idWidth = 5
     #     sym_len = 0
-    #     multiline = '\n' in row[3] 
+    #     multiline = '\n' in row[3]
     #     note_summary = gen_str + row[3].split('\n')[0]
     #     nslen0 = len(note_summary)
-    #     tooLong = nslen0 > self.snippet_width 
+    #     tooLong = nslen0 > self.snippet_width
     #     chr_key = ['|', '~', 'v', '&']
     #     if tooLong and multiline:
     #         end_chr = 3
     #     elif tooLong: # and not multiline
-    #         end_chr = 1 
+    #         end_chr = 1
     #     elif multiline: # and not too long
-    #         end_chr = 2 
+    #         end_chr = 2
     #     else:
     #         end_chr = 0
     #     note_summary = note_summary[:self.snippet_width].ljust(self.snippet_width) + chr_key[end_chr]
@@ -568,7 +568,7 @@ class Jot:
         group3.add_argument("-sqlite", action = "store_true", help="Open create.sqlite for editing")
         args = parser.parse_args()
         self.args = args if args else ''
-    
+
 #    def input_logic(self):
 #        args = self.args
 #        if args.identifier:
@@ -630,7 +630,7 @@ if __name__ == "__main__":
 #     with open(filename, 'rb') as file:
 #         blobData = file.read()
 #     return blobData
-# 
+#
 
 # def insertBLOB(empId, name, photo, resumeFile):
 #     try:
@@ -639,7 +639,7 @@ if __name__ == "__main__":
 #         print("Connected to SQLite")
 #         sqlite_insert_blob_query = """ INSERT INTO Files
 #                                   (id, name, photo, resume) VALUES (?, ?, ?, ?)"""
-# 
+#
 #         empPhoto = convertToBinaryData(photo)
 #         resume = convertToBinaryData(resumeFile)
 #         # Convert data into tuple format
@@ -648,13 +648,13 @@ if __name__ == "__main__":
 #         sqliteConnection.commit()
 #         print("Image and file inserted successfully as a BLOB into a table")
 #         cursor.close()
-# 
+#
 #     except sqlite3.Error as error:
 #         print("Failed to insert blob data into sqlite table", error)
 #     finally:
 #         if sqliteConnection:
 #             sqliteConnection.close()
 #             print("the sqlite connection is closed")
-# 
+#
 # insertBLOB(1, "Smith", "E:\pynative\Python\photos\smith.jpg", "E:\pynative\Python\photos\smith_resume.txt")
 # insertBLOB(2, "David", "E:\pynative\Python\photos\david.jpg", "E:\pynative\Python\photos\david_resume.txt")

--- a/jot/jot.py
+++ b/jot/jot.py
@@ -57,6 +57,11 @@ class Jot:
             for file in sourcefiles:
                 if file.endswith('.sqlite'):
                     shutil.move(self.SRC_DIR / file, self.JOT_DIR / file)
+            sourcefiles = os.listdir(self.SRC_DIR / 'dat')
+            destinationpath = self.JOT_DIR
+            for file in sourcefiles:
+                if file.endswith('.sqlite'):
+                    shutil.move(self.SRC_DIR / 'dat' / file, self.JOT_DIR / file)
 
         self.snippet_width = int(d['snippet_width']) # notes column print width
         self.DB_NAME = d['db_name']


### PR DESCRIPTION
This PR fixes a few issues with the first attempt to make `jot` installable.

* `default_config.csv` has been added to `MANIFEST.in`
* The location for `jot` configuration and database files has been migrated to `~/.jot`
   * This difference is clarified as `JOT_DIR` (where config/sqlite is stored) and `SRC_DIR` (where source code is located)
   * With the db files stored under the python package they were removed every time the package was re-installed

